### PR TITLE
Support release candidates

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -111,8 +111,9 @@ jobs:
           export GOPATH=$(pwd)/go
           export PATH=$PATH:$GOPATH/bin
           echo "Reva version was '$REVAVER'"
+          export ISRC=$(if [[ "${{ inputs.branch }}" == "master" ]] &&  [[ "${{ inputs.plugins }}" == "master" ]]; then echo false ; else echo true; fi)
           cd reva-release
-          go run prepare_release.go -author "cernbox-admins[bot]" -email "cernbox-admins@cern.ch" -reva-version "${REVAVER}"
+          go run prepare_release.go -author "cernbox-admins[bot]" -email "cernbox-admins@cern.ch" -reva-version "${REVAVER}" -release-candidate "${ISRC}"
           echo "version=$(awk '$1 == "Version:" {print $2}' cernbox-revad.spec)" >> $GITHUB_ENV
       - name: Push version
         uses: stefanzweifel/git-auto-commit-action@v4


### PR DESCRIPTION
With this PR, reva-release will automatically tag versions as a release candidates if the reva branch or the reva-plugins branch is not master